### PR TITLE
Use our own cors-anywhere server

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "sonarqube.corsAnywhereUrl": {
           "description": "The URL to a CORS proxy.",
           "type": "string",
-          "default": "https://cors-anywhere.herokuapp.com"
+          "default": "https://cors-anywhere.sgdev.org"
         },
         "sonarqube.repositoryNamePattern": {
           "description": "Regular expression with that is matched on the repository name to extract the capture groups for organization and project key templates.",


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3956, part of https://github.com/sourcegraph/sourcegraph/issues/15794