### PR TITLE
fix: use our CORS proxy as fallback

### DIFF
--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -46,7 +46,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                             return { editor, issues: [] as Issue[], errorMessage: null }
                         }
                         const corsAnyWhereUrl = new URL(
-                            config['sonarqube.corsAnywhereUrl'] || 'https://cors-anywhere.herokuapp.com'
+                            config['sonarqube.corsAnywhereUrl'] || 'https://cors-anywhere.sgdev.org'
                         )
                         const sonarqubeUrl = new URL(config['sonarqube.instanceUrl'] || 'https://sonarcloud.io/')
                         const apiOptions: ApiOptions = {


### PR DESCRIPTION
Our CORS proxy is the default setting value, but we fall back to the public cors-anywhere demo when there's no `corsAnywhereUrl` in user settings.