### PR TITLE
fix: search component not using the correct api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Show Sonarqube issues when browsing files on Sourcegraph.
 </picture>
 </p>
 
-➡️ Try it out on [github.com/apache/struts](https://sourcegraph.com/github.com/apache/struts/-/blob/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java)
+➡️ Try it out on [github.com/apache/struts](https://sourcegraph.com/github.com/apache/struts/-/blob/core/src/main/java/org/apache/struts2/action/CspReportAction.java#L60)
 
 You can toggle decorations with the Sonarqube button in the action toolbar.
 Each decoration links to the issue on Sonarqube.

--- a/src/api.ts
+++ b/src/api.ts
@@ -78,13 +78,14 @@ async function fetchApi(path: string, searchParameters: URLSearchParams, options
 }
 
 export async function searchComponents(
-    options: ApiOptions & { query: string; organization: string }
+    options: ApiOptions & { query: string; organization: string, component: string }
 ): Promise<Component[]> {
     const searchParameters = new URLSearchParams()
     searchParameters.set('organization', options.organization)
+    searchParameters.set('component', options.component)
     searchParameters.set('qualifiers', 'FIL,UTS')
     searchParameters.set('q', options.query)
-    const result = await fetchApi('api/components/search', searchParameters, options)
+    const result = await fetchApi('api/components/tree', searchParameters, options)
     return result.components
 }
 


### PR DESCRIPTION
According to the [docs](https://sonarcloud.io/web_api/api/components), `api/components/search` used to provide the ability to search for any component but this option has been removed and webservice `api/components/tree` is recommended for this purpose.

This change migrates the api.

#closes sourcegraph/sourcegraph#20918