### PR TITLE
Change the example CORS proxy to a Sourcegraph-hosted one

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The extension can be configured through JSON in user, organization or global set
   // CORS headers are necessary for the extension to fetch data, but Sonarqube does not send them by default.
   // Here you can customize the URL to an HTTP proxy that adds CORS headers.
   // By default Sourcegraph's CORS proxy is used.
-  "sonarqube.corsAnywhereUrl": "https://cors-anywhere.herokuapp.com"
+  "sonarqube.corsAnywhereUrl": "https://cors-anywhere.sgdev.org"
 }
 ```
 


### PR DESCRIPTION
https://cors-anywhere.herokuapp.com is now heavily restricted to just development use cases (see https://github.com/Rob--W/cors-anywhere/issues/301 ), so isn't a good experience when you're trying to figure out how to use this extension