### PR TITLE
sonarqube:9.0.0-community branch list api doesn't return commit info

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -113,7 +113,7 @@ export interface Branch {
         codeSmells?: number
     }
     analysisDate: string
-    commit: {
+    commit?: {
         sha: string
         author: {
             name: string

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -104,7 +104,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                         }
 
                         const branches = await listBranches({ project, ...apiOptions })
-                        const branch = branches.find(branch => branch.commit.sha === commitID)
+                        const branch = branches.find(branch => branch?.commit?.sha === commitID)
                         if (!branch) {
                             console.warn(
                                 `No Sonarqube branch found for commit ID ${commitID}, falling back to default branch`


### PR DESCRIPTION
<img width="730" alt="image" src="https://user-images.githubusercontent.com/66237089/126266806-6e6f2683-dd9e-486f-b0af-865d498f27e3.png">
As you can see /api/project_branches/list?project=xxx will return response as above. It doesn't have commit body which we need null check to make sure the fallback logic works.