### PR TITLE
feat: allow users to opt out of CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The extension can be configured through JSON in user, organization or global set
   // CORS headers are necessary for the extension to fetch data, but Sonarqube does not send them by default.
   // Here you can customize the URL to an HTTP proxy that adds CORS headers.
   // By default Sourcegraph's CORS proxy is used.
+  // Set this to `null` to opt out of using a CORS proxy.
   "sonarqube.corsAnywhereUrl": "https://cors-anywhere.sgdev.org"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -63,8 +63,11 @@
           "type": "string"
         },
         "sonarqube.corsAnywhereUrl": {
-          "description": "The URL to a CORS proxy.",
-          "type": "string",
+          "description": "The URL to a CORS proxy. Set to null to opt out of using a CORS proxy.",
+          "type": [
+            "string",
+            "null"
+          ],
           "default": "https://cors-anywhere.sgdev.org"
         },
         "sonarqube.repositoryNamePattern": {

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -22,7 +22,7 @@ interface Configuration {
     'sonarqube.showIssuesOnCodeViews'?: boolean
     'sonarqube.instanceUrl'?: string
     'sonarqube.apiToken'?: string
-    'sonarqube.corsAnywhereUrl'?: string
+    'sonarqube.corsAnywhereUrl'?: string | null
     'sonarqube.organizationPattern'?: string
     'sonarqube.organizationKeyTemplate'?: string
     'sonarqube.projectKeyTemplate'?: string
@@ -45,13 +45,20 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                         if (config['sonarqube.showIssuesOnCodeViews'] === false) {
                             return { editor, issues: [] as Issue[], errorMessage: null }
                         }
-                        const corsAnyWhereUrl = new URL(
-                            config['sonarqube.corsAnywhereUrl'] || 'https://cors-anywhere.sgdev.org'
-                        )
+                        const corsAnyWhereUrl =
+                            config['sonarqube.corsAnywhereUrl'] === null
+                                ? null
+                                : new URL(config['sonarqube.corsAnywhereUrl'] || 'https://cors-anywhere.sgdev.org')
+
                         const sonarqubeUrl = new URL(config['sonarqube.instanceUrl'] || 'https://sonarcloud.io/')
                         const apiOptions: ApiOptions = {
                             sonarqubeApiUrl: new URL(
-                                `${corsAnyWhereUrl.href.replace(/\/$/, '')}/${sonarqubeUrl.href.replace(/\/$/, '')}/`
+                                corsAnyWhereUrl
+                                    ? `${corsAnyWhereUrl.href.replace(/\/$/, '')}/${sonarqubeUrl.href.replace(
+                                          /\/$/,
+                                          ''
+                                      )}/`
+                                    : `${sonarqubeUrl.href.replace(/\/$/, '')}/`
                             ),
                             apiToken: config['sonarqube.apiToken'],
                         }


### PR DESCRIPTION
Closes #10.

We didn't account for private Sonarqube instances that do not require a CORS proxy when implementing this setting. Allow users to opt out of using a CORS proxy by setting `sonarqube.corsAnywhereUrl` to `null`.